### PR TITLE
browser watchdog pauses idle Chrome to free RAM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ STATUS.md
 PROJECT.md
 PLAN.md
 TODO.md
+AGENTS.md
 ROADMAP-personal.md
 research/
 notes/
@@ -54,6 +55,7 @@ scratch/
 .pi/
 .claude/
 .cursor/
+.opencode/*
 keys.md
 master-fetch-bug-report.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [Unreleased]
+
+### Added — browser watchdog pauses idle Chrome to free RAM
+
+After 60s of idleness (no `smart_fetch`/`screenshot` in flight), the watchdog
+sends `SIGSTOP` (Linux/macOS) or `psutil.suspend()` (Windows) to the shared
+Patchright Chrome process tree, making it eligible for OS memory eviction.
+On the next fetch/screenshot call, the browser is resumed in <1ms — no cold
+launch penalty. `HOUND_BROWSER_IDLE_TIMEOUT` env var (default 60) controls
+the idle threshold; set to 0 to disable.
+
+- `psutil>=5.9` added as a core dependency (lightweight, no C deps).
+- `_find_browser_pids()` discovers Chrome/Chromium child PIDs after browser launch.
+- `_mark_browser_busy()`/`_mark_browser_idle()` track in-flight fetches with a
+  race-safe counter (`asyncio.Lock`).
+- `_pause_browser()` freezes the process tree; double-checks busy count under lock.
+- `_resume_browser_if_paused()` resumes before every fetch, screenshot, and shutdown
+  (synchronous, sub-ms; no-op when not paused).
+- `_watchdog_loop()` runs as a background `asyncio.Task` every 15s.
+- `_ensure_auto_session()` resumes before reuse, captures PIDs on browser creation.
+- `_shutdown_close_sessions()` resumes before CDP close (avoids hang on suspended
+  process).
+
+### Tests
+
+- `tests/test_watchdog.py` — 32 tests (config, PID discovery, SIGSTOP/SIGCONT,
+  Windows suspend/resume, busy/idle counters, watchdog lifecycle, shutdown).
+
 ## [9.1.2] - 2026-07-07
 
 ### Packaging hardening on top of 9.1.1 startup work

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The lean install is fully functional: multi-engine keyless search with cross-bac
 |----------|---------|
 | `HOUND_SEARCH_PROXY` | Route all search-engine requests through your own proxy (`http://host:port`, `socks5://...`, or `user:pass@host:port`). For sustained heavy search use with a rotating / residential proxy. Not required for normal single-user use. |
 | `HOUND_SEARCH_MIN_INTERVAL` | Override the per-engine pacing floor (seconds, float). `0` = use the built-in defaults (DDG 1.2s, Bing 1.5s, Wikipedia 0.3s). Power-user tuning. |
+| `HOUND_BROWSER_IDLE_TIMEOUT` | Seconds of browser idleness before pausing the Chrome process tree (SIGSTOP/suspend) to free RAM. Resumed on next fetch in <1ms. Default 60. Set to 0 to disable. |
 
 No API keys or accounts are needed for anything: search is keyless and local.
 </details>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "httpx[http2]>=0.27",
     "fake-useragent>=2.0",
     "lxml>=5.0",
+    "psutil>=5.9",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/src/master_fetch/server.py
+++ b/src/master_fetch/server.py
@@ -155,6 +155,12 @@ MAX_BULK_URLS = 100  # hard cap to prevent DoS via unbounded parallel requests
 AUTO_SESSION_IDLE_TIMEOUT = 0  # 0 = keep browser alive forever. Pre-warmed at server startup (eager), shared by smart_fetch + screenshot.
 IDLE_CHECK_INTERVAL = 60  # How often to check for idle sessions (seconds)
 
+# Watchdog: pause the browser process tree (SIGSTOP on Linux/macOS, suspend on
+# Windows) after a period of idleness to free RAM. The browser is resumed on the
+# next fetch/screenshot call — no cold launch, sub-rms latency.
+_WATCHDOG_IDLE_TIMEOUT_DEFAULT = 60  # default seconds idle before pausing
+_WATCHDOG_CHECK_INTERVAL = 15  # seconds between watchdog checks
+
 # MCP initialize `instructions` — injected into the agent's context ONCE on
 # connect by clients that support it. This is the connect-time mastery doc:
 # the #1 workflow, the gotchas, and when to use each tool. Kept tight (~300
@@ -954,6 +960,18 @@ class MasterFetchServer:
         self._idle_monitor_task: Optional[Any] = None  # asyncio.Task for idle session cleanup
         self._auto_session_lock: Lock = Lock()  # serializes auto-session creation so the startup warm-up + a concurrent fetch never spawn a 2nd browser
 
+        # Watchdog: pause idle browser to free RAM (v9.1.3)
+        self._watchdog_idle_timeout: int = int(
+            os.environ.get("HOUND_BROWSER_IDLE_TIMEOUT", str(_WATCHDOG_IDLE_TIMEOUT_DEFAULT))
+        )
+        self._auto_stealthy_pids: list[int] = []
+        self._auto_stealthy_busy_count: int = 0
+        self._auto_stealthy_paused: bool = False
+        self._auto_stealthy_last_idle_time: float = 0.0
+        self._auto_stealthy_busy_lock: Lock = Lock()
+        self._watchdog_task: Optional[asyncio.Task] = None
+        self._watchdog_shutdown: bool = False
+
     # ─── Core helpers ─────────────────────────────────────────────
 
     async def _get_session(self, session_id: str, expected_type: Optional[SessionType]) -> _SessionEntry:
@@ -990,14 +1008,18 @@ class MasterFetchServer:
         Idle timeout: when AUTO_SESSION_IDLE_TIMEOUT > 0, auto sessions close
         after that many seconds of inactivity. When it is 0 (default), the
         browser is kept alive forever and no idle monitor is started.
+
+        Watchdog: if the browser was paused to free RAM, resumes it before reuse.
         """
         attr = "_auto_dynamic_id" if session_type == "dynamic" else "_auto_stealthy_id"
         ts_attr = "_auto_dynamic_last_used" if session_type == "dynamic" else "_auto_stealthy_last_used"
 
-        # Fast path: reuse an existing alive session.
+        # Fast path: reuse an existing alive session. Resume if watchdog paused it.
         async with self._sessions_lock:
             existing_id = getattr(self, attr)
             if existing_id and existing_id in self._sessions and self._sessions[existing_id].session._is_alive:
+                if session_type == "stealthy":
+                    self._resume_browser_if_paused()
                 setattr(self, ts_attr, now())
                 self._ensure_idle_monitor()
                 return existing_id
@@ -1012,9 +1034,16 @@ class MasterFetchServer:
             async with self._sessions_lock:
                 existing_id = getattr(self, attr)
                 if existing_id and existing_id in self._sessions and self._sessions[existing_id].session._is_alive:
+                    if session_type == "stealthy":
+                        self._resume_browser_if_paused()
                     setattr(self, ts_attr, now())
                     self._ensure_idle_monitor()
                     return existing_id
+            # Resume if browser was paused (e.g. watchdog paused it after the idle
+            # monitor killed the old session and before this new one was created —
+            # the PIDs are stale but _resume_browser_if_paused checks _paused first).
+            if session_type == "stealthy":
+                self._resume_browser_if_paused()
             # Create outside the sessions lock (expensive — browser launch) but
             # inside the creation lock (no concurrent 2nd launch).
             sid = await self.open_session(session_type=session_type, headless=True)
@@ -1030,6 +1059,13 @@ class MasterFetchServer:
                     return existing_id
                 setattr(self, attr, sid.session_id)
                 setattr(self, ts_attr, now())
+
+        # Capture browser PIDs for watchdog after creation
+        if session_type == "stealthy":
+            self._auto_stealthy_pids = self._find_browser_pids()
+            self._auto_stealthy_paused = False
+            self._auto_stealthy_last_idle_time = now()
+            await self._ensure_watchdog()
 
         self._ensure_idle_monitor()
         return sid.session_id
@@ -1153,6 +1189,19 @@ class MasterFetchServer:
         loop is alive, then close any lingering asyncio subprocess transports
         so their __del__ is a no-op (they're already closing).
         """
+        # Resume browser if watchdog paused it — session.close() communicates
+        # with the browser via CDP and would hang on a suspended process.
+        self._resume_browser_if_paused()
+
+        # Stop the watchdog background task
+        self._watchdog_shutdown = True
+        if self._watchdog_task is not None and not self._watchdog_task.done():
+            self._watchdog_task.cancel()
+            try:
+                await self._watchdog_task
+            except BaseException:
+                pass
+
         async with self._sessions_lock:
             entries = list(self._sessions.items())
             self._sessions.clear()
@@ -1205,6 +1254,136 @@ class MasterFetchServer:
                     transport.close()
             except BaseException:
                 pass
+
+    # ─── Watchdog ──────────────────────────────────────────────────
+
+    def _find_browser_pids(self) -> list[int]:
+        """Find Chrome/Chromium child processes of this process.
+
+        Called after session.start() creates the browser tree. Returns the PIDs
+        of all descendant processes with 'chrome' or 'chromium' in their name.
+        Best-effort; returns [] on failure (watchdog will skip pausing).
+        """
+        import psutil
+        try:
+            parent = psutil.Process(os.getpid())
+            children = parent.children(recursive=True)
+            pids = []
+            for child in children:
+                try:
+                    name = child.name().lower()
+                    if "chrome" in name or "chromium" in name:
+                        pids.append(child.pid)
+                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                    pass
+            return pids
+        except Exception:
+            return []
+
+    def _resume_browser_if_paused(self) -> None:
+        """Resume the browser process tree if it was paused by the watchdog.
+
+        Synchronous and fast (SIGCONT/suspend-resume is sub-ms). Must be called
+        BEFORE any operation that communicates with the browser (fetch, close),
+        otherwise those operations hang forever on a suspended process.
+
+        Idempotent: no-op if the browser is not paused.
+        """
+        if not self._auto_stealthy_paused:
+            return
+        if not self._auto_stealthy_pids:
+            self._auto_stealthy_paused = False
+            return
+        import os as _os
+        pids = list(self._auto_stealthy_pids)
+        is_windows = sys.platform == "win32"
+        for pid in pids:
+            try:
+                if is_windows:
+                    import psutil
+                    psutil.Process(pid).resume()
+                else:
+                    import signal
+                    _os.kill(pid, signal.SIGCONT)
+            except Exception:
+                pass
+        self._auto_stealthy_paused = False
+        self._auto_stealthy_last_idle_time = now()
+        logger.debug("Watchdog: resumed browser (PIDs: %s)", pids)
+
+    async def _mark_browser_busy(self) -> None:
+        """Mark the auto stealthy browser as busy (a fetch/screenshot is in flight)."""
+        async with self._auto_stealthy_busy_lock:
+            self._auto_stealthy_busy_count += 1
+
+    async def _mark_browser_idle(self) -> None:
+        """Mark the auto stealthy browser as idle (fetch/screenshot completed)."""
+        async with self._auto_stealthy_busy_lock:
+            self._auto_stealthy_busy_count = max(0, self._auto_stealthy_busy_count - 1)
+            if self._auto_stealthy_busy_count == 0:
+                self._auto_stealthy_last_idle_time = now()
+
+    async def _pause_browser(self) -> None:
+        """Pause the browser process tree (SIGSTOP/suspend) to free RAM.
+
+        Double-checks busy_count under lock before pausing to prevent races
+        with an incoming fetch.
+        """
+        if not self._auto_stealthy_pids:
+            self._auto_stealthy_pids = self._find_browser_pids()
+        if not self._auto_stealthy_pids:
+            return
+        async with self._auto_stealthy_busy_lock:
+            if self._auto_stealthy_busy_count > 0:
+                return
+            pids = list(self._auto_stealthy_pids)
+        import os as _os
+        is_windows = sys.platform == "win32"
+        for pid in pids:
+            try:
+                if is_windows:
+                    import psutil
+                    psutil.Process(pid).suspend()
+                else:
+                    import signal
+                    _os.kill(pid, signal.SIGSTOP)
+            except Exception:
+                pass
+        self._auto_stealthy_paused = True
+        logger.debug("Watchdog: paused browser after idle (PIDs: %s)", pids)
+
+    async def _ensure_watchdog(self) -> None:
+        """Start the watchdog task if enabled and not already running."""
+        if self._watchdog_idle_timeout <= 0:
+            return
+        if self._watchdog_task is not None and not self._watchdog_task.done():
+            return
+        self._watchdog_shutdown = False
+        self._watchdog_task = asyncio.create_task(self._watchdog_loop())
+
+    async def _watchdog_loop(self) -> None:
+        """Background task: pause the browser after _watchdog_idle_timeout of idleness."""
+        try:
+            while not self._watchdog_shutdown:
+                await asyncio_sleep(_WATCHDOG_CHECK_INTERVAL)
+                try:
+                    if self._watchdog_idle_timeout <= 0:
+                        continue
+                    if self._auto_stealthy_paused:
+                        continue
+                    async with self._auto_stealthy_busy_lock:
+                        busy = self._auto_stealthy_busy_count
+                        last_idle = self._auto_stealthy_last_idle_time
+                    if busy == 0 and last_idle > 0 and (now() - last_idle) > self._watchdog_idle_timeout:
+                        await self._pause_browser()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception("Watchdog check failed, will retry on next cycle")
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._watchdog_task = None
 
     async def _finalize_result(
         self,
@@ -1452,11 +1631,18 @@ class MasterFetchServer:
             except Exception as exc:
                 captured["error"] = exc
 
-        await entry.session.fetch(
-            url, wait=wait, timeout=timeout, network_idle=network_idle,
-            wait_selector=wait_selector, wait_selector_state=wait_selector_state,
-            page_action=_capture,
-        )
+        using_auto = bool(self._auto_stealthy_id and ssid == self._auto_stealthy_id)
+        if using_auto:
+            await self._mark_browser_busy()
+        try:
+            await entry.session.fetch(
+                url, wait=wait, timeout=timeout, network_idle=network_idle,
+                wait_selector=wait_selector, wait_selector_state=wait_selector_state,
+                page_action=_capture,
+            )
+        finally:
+            if using_auto:
+                await self._mark_browser_idle()
 
         if "error" in captured:
             raise captured["error"]
@@ -1971,17 +2157,25 @@ class MasterFetchServer:
 
         if session_id:
             entry = await self._get_session(session_id, "stealthy")
-            timed_tasks = [
-                _timed(entry.session.fetch(
-                    url, wait=wait, timeout=timeout, google_search=google_search,
-                    extra_headers=extra_headers, disable_resources=disable_resources,
-                    wait_selector=wait_selector, wait_selector_state=wait_selector_state,
-                    network_idle=network_idle, proxy=proxy, solve_cloudflare=solve_cloudflare,
-                    page_action=page_action,
-                ))
-                for url in urls
-            ]
-            timed_responses = await gather(*timed_tasks, return_exceptions=True)
+
+            using_auto = bool(self._auto_stealthy_id and session_id == self._auto_stealthy_id)
+            if using_auto:
+                await self._mark_browser_busy()
+            try:
+                timed_tasks = [
+                    _timed(entry.session.fetch(
+                        url, wait=wait, timeout=timeout, google_search=google_search,
+                        extra_headers=extra_headers, disable_resources=disable_resources,
+                        wait_selector=wait_selector, wait_selector_state=wait_selector_state,
+                        network_idle=network_idle, proxy=proxy, solve_cloudflare=solve_cloudflare,
+                        page_action=page_action,
+                    ))
+                    for url in urls
+                ]
+                timed_responses = await gather(*timed_tasks, return_exceptions=True)
+            finally:
+                if using_auto:
+                    await self._mark_browser_idle()
         else:
             s = _get_scrapling()
             async with s.AsyncStealthySession(

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,358 @@
+"""Tests for the browser watchdog (v9.1.3): pause idle Chrome to free RAM."""
+
+import os
+import asyncio
+import signal
+import sys
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import pytest
+
+from master_fetch.server import MasterFetchServer
+
+
+class TestWatchdogConfig:
+    def test_default_idle_timeout(self, monkeypatch):
+        monkeypatch.delenv("HOUND_BROWSER_IDLE_TIMEOUT", raising=False)
+        srv = MasterFetchServer()
+        assert srv._watchdog_idle_timeout == 60
+
+    def test_env_var_sets_timeout(self, monkeypatch):
+        monkeypatch.setenv("HOUND_BROWSER_IDLE_TIMEOUT", "30")
+        srv = MasterFetchServer()
+        assert srv._watchdog_idle_timeout == 30
+
+    def test_env_var_zero_disables_watchdog(self, monkeypatch):
+        monkeypatch.setenv("HOUND_BROWSER_IDLE_TIMEOUT", "0")
+        srv = MasterFetchServer()
+        assert srv._watchdog_idle_timeout == 0
+
+    def test_initial_state(self):
+        srv = MasterFetchServer()
+        assert srv._auto_stealthy_pids == []
+        assert srv._auto_stealthy_busy_count == 0
+        assert srv._auto_stealthy_paused is False
+        assert srv._auto_stealthy_last_idle_time == 0.0
+        assert srv._watchdog_task is None
+        assert srv._watchdog_shutdown is False
+
+
+class TestFindBrowserPids:
+    def test_no_children_returns_empty(self, monkeypatch):
+        srv = MasterFetchServer()
+        mock_parent = MagicMock()
+        mock_parent.children.return_value = []
+        monkeypatch.setattr("psutil.Process", lambda pid: mock_parent)
+        pids = srv._find_browser_pids()
+        assert pids == []
+
+    def test_finds_chrome_named_process(self, monkeypatch):
+        srv = MasterFetchServer()
+        mock_parent = MagicMock()
+        mock_child = MagicMock()
+        mock_child.pid = 12345
+        mock_child.name.return_value = "chrome"
+        mock_parent.children.return_value = [mock_child]
+
+        monkeypatch.setattr("psutil.Process", lambda pid: mock_parent)
+        pids = srv._find_browser_pids()
+        assert 12345 in pids
+
+    def test_finds_chromium_named_process(self, monkeypatch):
+        srv = MasterFetchServer()
+        mock_parent = MagicMock()
+        mock_child = MagicMock()
+        mock_child.pid = 67890
+        mock_child.name.return_value = "chromium-browser"
+        mock_parent.children.return_value = [mock_child]
+
+        monkeypatch.setattr("psutil.Process", lambda pid: mock_parent)
+        pids = srv._find_browser_pids()
+        assert 67890 in pids
+
+    def test_filters_non_chrome_children(self, monkeypatch):
+        srv = MasterFetchServer()
+        mock_parent = MagicMock()
+        chrome_child = MagicMock()
+        chrome_child.pid = 111
+        chrome_child.name.return_value = "chrome"
+        python_child = MagicMock()
+        python_child.pid = 222
+        python_child.name.return_value = "python"
+        mock_parent.children.return_value = [chrome_child, python_child]
+
+        monkeypatch.setattr("psutil.Process", lambda pid: mock_parent)
+        pids = srv._find_browser_pids()
+        assert pids == [111]
+
+    def test_handles_no_such_process(self, monkeypatch):
+        srv = MasterFetchServer()
+        mock_parent = MagicMock()
+        import psutil
+        mock_child = MagicMock()
+        mock_child.name.side_effect = psutil.NoSuchProcess(123)
+        mock_parent.children.return_value = [mock_child]
+        monkeypatch.setattr("psutil.Process", lambda pid: mock_parent)
+        pids = srv._find_browser_pids()
+        assert pids == []
+
+    def test_handles_psutil_failure_gracefully(self, monkeypatch):
+        srv = MasterFetchServer()
+        monkeypatch.setattr("psutil.Process", lambda pid: (_ for _ in ()).throw(RuntimeError("boom")))
+        pids = srv._find_browser_pids()
+        assert pids == []
+
+
+class TestResumeBrowserIfPaused:
+    def test_noop_when_not_paused(self):
+        srv = MasterFetchServer()
+        srv._auto_stealthy_paused = False
+        srv._resume_browser_if_paused()
+        assert srv._auto_stealthy_paused is False
+
+    def test_noop_when_no_pids(self):
+        srv = MasterFetchServer()
+        srv._auto_stealthy_paused = True
+        srv._auto_stealthy_pids = []
+        srv._resume_browser_if_paused()
+        assert srv._auto_stealthy_paused is False
+
+    def test_sends_sigcont_on_linux(self, monkeypatch):
+        if sys.platform == "win32":
+            pytest.skip("SIGCONT is POSIX-only")
+        srv = MasterFetchServer()
+        srv._auto_stealthy_paused = True
+        srv._auto_stealthy_pids = [12345, 12346]
+        mock_kill = MagicMock()
+        monkeypatch.setattr(os, "kill", mock_kill)
+        monkeypatch.setattr(sys, "platform", "linux")
+        srv._resume_browser_if_paused()
+        assert srv._auto_stealthy_paused is False
+        assert mock_kill.call_count == 2
+        mock_kill.assert_any_call(12345, signal.SIGCONT)
+        mock_kill.assert_any_call(12346, signal.SIGCONT)
+
+    def test_sigcont_errors_are_swallowed(self, monkeypatch):
+        if sys.platform == "win32":
+            pytest.skip("SIGCONT is POSIX-only")
+        srv = MasterFetchServer()
+        srv._auto_stealthy_paused = True
+        srv._auto_stealthy_pids = [12345]
+        mock_kill = MagicMock(side_effect=ProcessLookupError)
+        monkeypatch.setattr(os, "kill", mock_kill)
+        monkeypatch.setattr(sys, "platform", "linux")
+        srv._resume_browser_if_paused()
+        assert srv._auto_stealthy_paused is False
+
+    def test_uses_psutil_resume_on_windows(self, monkeypatch):
+        srv = MasterFetchServer()
+        srv._auto_stealthy_paused = True
+        srv._auto_stealthy_pids = [12345]
+        mock_proc = MagicMock()
+        mock_proc.resume = MagicMock()
+        monkeypatch.setattr("psutil.Process", lambda pid: mock_proc)
+        monkeypatch.setattr(sys, "platform", "win32")
+        srv._resume_browser_if_paused()
+        assert srv._auto_stealthy_paused is False
+        mock_proc.resume.assert_called_once()
+
+    def test_resets_last_idle_time(self):
+        srv = MasterFetchServer()
+        srv._auto_stealthy_paused = True
+        srv._auto_stealthy_pids = [1]
+        srv._auto_stealthy_last_idle_time = 100.0
+        srv._resume_browser_if_paused()
+        assert srv._auto_stealthy_last_idle_time > 100.0
+
+
+class TestMarkBrowserBusyIdle:
+    @pytest.mark.asyncio
+    async def test_busy_increments_counter(self):
+        srv = MasterFetchServer()
+        await srv._mark_browser_busy()
+        assert srv._auto_stealthy_busy_count == 1
+
+    @pytest.mark.asyncio
+    async def test_busy_concurrent(self):
+        srv = MasterFetchServer()
+        await asyncio.gather(
+            srv._mark_browser_busy(),
+            srv._mark_browser_busy(),
+            srv._mark_browser_busy(),
+        )
+        assert srv._auto_stealthy_busy_count == 3
+
+    @pytest.mark.asyncio
+    async def test_idle_decrements_counter(self):
+        srv = MasterFetchServer()
+        srv._auto_stealthy_busy_count = 2
+        await srv._mark_browser_idle()
+        assert srv._auto_stealthy_busy_count == 1
+        await srv._mark_browser_idle()
+        assert srv._auto_stealthy_busy_count == 0
+
+    @pytest.mark.asyncio
+    async def test_idle_records_timestamp_when_reaches_zero(self):
+        srv = MasterFetchServer()
+        srv._auto_stealthy_busy_count = 1
+        assert srv._auto_stealthy_last_idle_time == 0.0
+        await srv._mark_browser_idle()
+        assert srv._auto_stealthy_last_idle_time > 0.0
+
+    @pytest.mark.asyncio
+    async def test_idle_never_goes_negative(self):
+        srv = MasterFetchServer()
+        await srv._mark_browser_idle()
+        assert srv._auto_stealthy_busy_count == 0
+        await srv._mark_browser_idle()
+        assert srv._auto_stealthy_busy_count == 0
+
+
+class TestPauseBrowser:
+    @pytest.mark.asyncio
+    async def test_noop_when_no_pids_and_none_found(self, monkeypatch):
+        srv = MasterFetchServer()
+        monkeypatch.setattr(srv, "_find_browser_pids", lambda: [])
+        await srv._pause_browser()
+        assert srv._auto_stealthy_paused is False
+
+    @pytest.mark.asyncio
+    async def test_noop_when_busy(self, monkeypatch):
+        srv = MasterFetchServer()
+        srv._auto_stealthy_pids = [12345]
+        srv._auto_stealthy_busy_count = 1
+        monkeypatch.setattr(os, "kill", MagicMock())
+        monkeypatch.setattr(sys, "platform", "linux")
+        await srv._pause_browser()
+        assert srv._auto_stealthy_paused is False
+
+    @pytest.mark.asyncio
+    async def test_sends_sigstop_on_linux(self, monkeypatch):
+        if sys.platform == "win32":
+            pytest.skip("SIGSTOP is POSIX-only")
+        srv = MasterFetchServer()
+        srv._auto_stealthy_pids = [12345, 12346]
+        mock_kill = MagicMock()
+        monkeypatch.setattr(os, "kill", mock_kill)
+        monkeypatch.setattr(sys, "platform", "linux")
+        await srv._pause_browser()
+        assert srv._auto_stealthy_paused is True
+        assert mock_kill.call_count == 2
+        mock_kill.assert_any_call(12345, signal.SIGSTOP)
+        mock_kill.assert_any_call(12346, signal.SIGSTOP)
+
+    @pytest.mark.asyncio
+    async def test_uses_psutil_suspend_on_windows(self, monkeypatch):
+        srv = MasterFetchServer()
+        srv._auto_stealthy_pids = [12345]
+        mock_proc = MagicMock()
+        mock_proc.suspend = MagicMock()
+        monkeypatch.setattr("psutil.Process", lambda pid: mock_proc)
+        monkeypatch.setattr(sys, "platform", "win32")
+        await srv._pause_browser()
+        assert srv._auto_stealthy_paused is True
+        mock_proc.suspend.assert_called_once()
+
+
+class TestEnsureWatchdog:
+    @pytest.mark.asyncio
+    async def test_does_not_start_when_disabled(self):
+        srv = MasterFetchServer()
+        srv._watchdog_idle_timeout = 0
+        await srv._ensure_watchdog()
+        assert srv._watchdog_task is None
+
+    @pytest.mark.asyncio
+    async def test_starts_when_enabled(self):
+        srv = MasterFetchServer()
+        srv._watchdog_idle_timeout = 60
+        await srv._ensure_watchdog()
+        assert srv._watchdog_task is not None
+        assert not srv._watchdog_task.done()
+        srv._watchdog_shutdown = True
+        srv._watchdog_task.cancel()
+        try:
+            await srv._watchdog_task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_idempotent(self):
+        srv = MasterFetchServer()
+        srv._watchdog_idle_timeout = 60
+        await srv._ensure_watchdog()
+        task1 = srv._watchdog_task
+        await srv._ensure_watchdog()
+        assert srv._watchdog_task is task1
+        srv._watchdog_shutdown = True
+        srv._watchdog_task.cancel()
+        try:
+            await srv._watchdog_task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_restarts_if_task_crashed(self):
+        srv = MasterFetchServer()
+        srv._watchdog_idle_timeout = 60
+        await srv._ensure_watchdog()
+        srv._watchdog_task.cancel()
+        try:
+            await srv._watchdog_task
+        except asyncio.CancelledError:
+            pass
+        await srv._ensure_watchdog()
+        assert srv._watchdog_task is not None
+        assert not srv._watchdog_task.done()
+        srv._watchdog_shutdown = True
+        srv._watchdog_task.cancel()
+        try:
+            await srv._watchdog_task
+        except asyncio.CancelledError:
+            pass
+
+
+class TestShutdownCloseSessions:
+    @pytest.mark.asyncio
+    async def test_resumes_before_close(self):
+        srv = MasterFetchServer()
+        resumed = False
+
+        def fake_resume():
+            nonlocal resumed
+            resumed = True
+        srv._resume_browser_if_paused = fake_resume
+        with patch.object(srv, "_watchdog_task", None):
+            await srv._shutdown_close_sessions()
+        assert resumed is True
+
+    @pytest.mark.asyncio
+    async def test_cancels_watchdog_task(self):
+        srv = MasterFetchServer()
+        srv._auto_stealthy_paused = False
+        srv._auto_stealthy_pids = []
+
+        async def fake_loop():
+            try:
+                while not srv._watchdog_shutdown:
+                    await asyncio.sleep(0.01)
+            except asyncio.CancelledError:
+                raise
+            finally:
+                srv._watchdog_task = None
+        srv._watchdog_task = asyncio.create_task(fake_loop())
+        await asyncio.sleep(0.05)  # let task start and begin sleeping
+
+        await srv._shutdown_close_sessions()
+
+        assert srv._watchdog_shutdown is True
+        assert srv._watchdog_task is None
+
+
+class TestWatchdogEnvVarDisabled:
+    @pytest.mark.asyncio
+    async def test_ensure_watchdog_noop_when_disabled_by_init(self):
+        srv = MasterFetchServer()
+        srv._watchdog_idle_timeout = 0
+        await srv._ensure_watchdog()
+        assert srv._watchdog_task is None


### PR DESCRIPTION
After 60s of idleness (no smart_fetch/screenshot in flight), the watchdog sends SIGSTOP (Linux/macOS) or psutil.suspend() (Windows) to the shared Patchright Chrome process tree, making it eligible for OS memory eviction. On the next fetch/screenshot call, the browser is resumed, no cold launch penalty.

Configuration:
- HOUND_BROWSER_IDLE_TIMEOUT env var (default 60s), set to 0 to disable
- psutil added as a core dependency for cross-platform process management

Implementation:
- _find_browser_pids() discovers Chrome/Chromium child PIDs via psutil
- _mark_browser_busy/_idle() tracks in-flight fetches with a counter
- _pause_browser() freezes the process tree (race-safe busy check)
- _resume_browser_if_paused() unfreezes before fetch/screenshot/close
- _watchdog_loop() runs as a background asyncio task every 15s
- _ensure_auto_session resumes before reuse, captures PIDs on creation
- _shutdown_close_sessions resumes before CDP close (avoids hang)

Tests: tests/test_watchdog.py — 32 tests covering config, PID discovery, pause/resume signals, busy/idle counters, watchdog lifecycle, and shutdown integration. 582 total tests pass, zero regressions.

## Summary

After 60s of idleness (no smart_fetch/screenshot in flight), the watchdog sends SIGSTOP (Linux/macOS) or psutil.suspend() (Windows) to the shared Patchright Chrome process tree, making it eligible for OS memory eviction. On the next fetch/screenshot call, the browser is resumed, no cold launch penalty.

Closes #1 

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New capability
- [ ] Reliability / hardening
- [ ] Docs / README / tool defs
- [ ] Breaking change (note the migration below)

## Checklist

- [x] The change is functional, not a cosmetic re-label of an existing capability.
- [x] `pytest tests/` passes locally (`pip install -e . --no-deps` first if you edited `src/`).
- [x] New behavior has a test that would actually fail without the change.
- [x] No new heavy module-level import in `server.py` (it stalls the MCP handshake; lazy-import at the call site instead).
- [x] `CHANGELOG.md` updated under `## [Unreleased]` (or the relevant version).
- [x] README / tool descriptions updated if the user-facing surface changed.
- [x] Version stays in sync across `pyproject.toml`, `src/master_fetch/__init__.py`, `CHANGELOG.md`, and the git tag (if releasing).

## Notes for review

<!-- Anything reviewers should pay attention to: failure paths tested, perf
impact, token-cost change on the tool defs, etc. -->