### PR TITLE
Classify paywalls from visible text and explicit attributes, not a bare token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `detect_page_type()` no longer classifies a page as a paywall solely because
+  raw HTML contains the bare token `paywall`. Concrete visible subscription
+  prompts and active, exact paywall data attributes remain signals; false-like
+  values, foreign attribute names, and examples inside metadata, scripts,
+  styles, fallbacks, templates, or comments are ignored. Visible prompts remain
+  detectable across character references and inline formatting boundaries.
+
 ## [11.1.6] - 2026-07-21
 
 ### Fixed: smart_crawl does not bypass Cloudflare on protected sites

--- a/src/master_fetch/envelope.py
+++ b/src/master_fetch/envelope.py
@@ -2,9 +2,8 @@
 signals computed for every fetch so an agent gets trust + currency + the next
 step without a second call.
 
-All functions are dependency-free (stdlib + regex) and run in microseconds on
-already-extracted HTML / the URL string, so the envelope adds negligible cost
-to every response.
+All functions use only the standard library and run on already-extracted HTML /
+the URL string, keeping the envelope self-contained and low-overhead.
 
 Design principles:
 - CONSERVATIVE over RECALL. A wrong ``is_official=True`` or a mislabelled
@@ -21,6 +20,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, date, timezone
+from html.parser import HTMLParser
 from typing import Any
 from urllib.parse import urlparse
 
@@ -190,7 +190,98 @@ _DOCS_MARKERS = ("mkdocs", "docusaurus", "readthedocs", "sphinx-document",
 _PAYWALL_MARKERS = ("subscribe to continue", "subscribe to read", "this article is for subscribers",
                     "create a free account to continue", "sign in to continue reading",
                     "you've reached your free article limit", "subscriber-only content",
-                    "premium content", "paywall")
+                    "premium content")
+# Explicit HTML data attributes are a structural paywall signal. Deliberately do
+# not match the bare word "paywall": it can appear in ordinary README links,
+# explanatory copy, scripts, or metadata. Parse HTML so attribute names are
+# matched exactly and attribute values cannot impersonate names.
+_PAYWALL_ATTRIBUTE_NAMES = frozenset({
+    "data-paywall",
+    "data-content-gate",
+    "data-subscription-wall",
+})
+_FALSE_PAYWALL_ATTRIBUTE_VALUES = frozenset({
+    "0", "false", "no", "off", "disabled", "none", "null",
+})
+_PAYWALL_IGNORED_TAGS = frozenset({"script", "style", "noscript", "template"})
+_PAYWALL_METADATA_TAGS = frozenset({"base", "link", "meta"})
+_PAYWALL_BLOCK_TAGS = frozenset({
+    "address", "article", "aside", "blockquote", "br", "dd", "div", "dl", "dt",
+    "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2", "h3", "h4",
+    "h5", "h6", "header", "hr", "li", "main", "nav", "ol", "p", "pre", "section",
+    "table", "td", "th", "tr", "ul",
+})
+
+
+class _PaywallEvidenceParser(HTMLParser):
+    """Collect visible text and active, exact paywall attributes."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.visible_text: list[str] = []
+        self.has_active_attribute = False
+        self._ignored_stack: list[str] = []
+
+    def _inspect_attributes(self, attrs: list[tuple[str, str | None]]) -> None:
+        for name, value in attrs:
+            if name.lower() not in _PAYWALL_ATTRIBUTE_NAMES:
+                continue
+            normalized = value.strip().lower() if value is not None else None
+            if normalized not in _FALSE_PAYWALL_ATTRIBUTE_VALUES:
+                self.has_active_attribute = True
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if self._ignored_stack:
+            if tag in _PAYWALL_IGNORED_TAGS:
+                self._ignored_stack.append(tag)
+            return
+        if tag in _PAYWALL_IGNORED_TAGS:
+            self._ignored_stack.append(tag)
+            return
+        if tag not in _PAYWALL_METADATA_TAGS:
+            self._inspect_attributes(attrs)
+        if tag in _PAYWALL_BLOCK_TAGS:
+            self.visible_text.append(" ")
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if (
+            not self._ignored_stack
+            and tag not in _PAYWALL_IGNORED_TAGS
+            and tag not in _PAYWALL_METADATA_TAGS
+        ):
+            self._inspect_attributes(attrs)
+            if tag in _PAYWALL_BLOCK_TAGS:
+                self.visible_text.append(" ")
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if self._ignored_stack:
+            if tag in self._ignored_stack:
+                while self._ignored_stack.pop() != tag:
+                    pass
+            return
+        if tag in _PAYWALL_BLOCK_TAGS:
+            self.visible_text.append(" ")
+
+    def handle_data(self, data: str) -> None:
+        if not self._ignored_stack:
+            self.visible_text.append(data)
+
+
+def _paywall_evidence(html: str) -> tuple[str, bool]:
+    """Return visible page text and whether an active paywall attribute exists."""
+    parser = _PaywallEvidenceParser()
+    try:
+        parser.feed(html)
+        parser.close()
+    except Exception:
+        # Malformed upstream HTML must not break the fetch response.
+        return "", False
+    return " ".join("".join(parser.visible_text).split()), parser.has_active_attribute
+
+
 # A redirect via <meta http-equiv=refresh> or a JS location.href assignment.
 _META_REFRESH_RE = re.compile(
     r'<meta\b[^>]*?http-equiv=["\']refresh["\'][^>]*?content=["\'][^"\']*url=',
@@ -267,8 +358,12 @@ def detect_page_type(
     if _META_REFRESH_RE.search(low) or (_JS_REDIRECT_RE.search(low) and extracted_text_len < 500):
         return "redirect"
 
-    # Paywall phrases (strong, specific).
-    if any(m in low for m in _PAYWALL_MARKERS):
+    # Parse visible text and exact structural attributes. Raw-HTML prefilters are
+    # unsafe here because entities and inline tags can split a real signal.
+    visible_text, has_active_paywall_attribute = _paywall_evidence(html)
+    if any(marker in visible_text.lower() for marker in _PAYWALL_MARKERS):
+        return "paywall"
+    if has_active_paywall_attribute:
         return "paywall"
 
     # Forum / Q&A / docs markers (substring match in the raw HTML).

--- a/tests/test_v10_envelope.py
+++ b/tests/test_v10_envelope.py
@@ -128,8 +128,96 @@ def test_page_type_article_with_many_links_not_list():
 
 
 def test_page_type_paywall():
-    html = "<main><p>Subscribe to continue reading this article.</p></main>"
+    html = "<main><p>Subscribe <strong>to continue</strong> reading this article.</p></main>"
     assert detect_page_type(html, "https://x.com", "text/html", 80) == "paywall"
+
+
+def test_page_type_paywall_phrase_remains_a_paywall():
+    html = "<main><p>This article is for subscribers.</p></main>"
+    assert detect_page_type(html, "https://x.com", "text/html", 80) == "paywall"
+
+
+def test_page_type_encoded_or_inline_split_paywall_phrase_is_detected():
+    html_values = (
+        "<article>subscr&#105;be to continue</article>",
+        "<article>Sub<strong>scribe</strong> to continue</article>",
+        "<article>Subscribe <em>to</em> <span>continue</span></article>",
+        "<article>This article is for sub<strong>scribers</strong></article>",
+        (
+            "<template><noscript>hidden</template></noscript>"
+            "<article>Subscribe to continue</article>"
+        ),
+    )
+    for html in html_values:
+        assert detect_page_type(html, "https://x.com", "text/html", 80) == "paywall"
+
+
+def test_page_type_does_not_join_words_across_block_boundaries():
+    html = "<article><p>Sub</p><p>scribe to continue.</p></article>"
+    assert detect_page_type(html, "https://x.com", "text/html", 80) == "article"
+
+
+def test_page_type_visible_paywall_detector_explanation_is_not_a_paywall():
+    html = "<article><p>The paywall detector labels subscription prompts.</p></article>"
+    assert detect_page_type(html, "https://x.com", "text/html", 80) == "article"
+
+
+def test_page_type_readme_login_paywall_link_is_not_a_paywall():
+    html = '<article><a href="/login/paywall">login/paywall</a><p>Project README.</p></article>'
+    assert detect_page_type(html, "https://github.com/dondai1234/master-fetch", "text/html", 80) == "article"
+
+
+def test_page_type_script_and_meta_paywall_mentions_are_not_a_paywall():
+    html = (
+        '<meta name="description" data-paywall="true" '
+        'content="subscribe to continue; paywall detector docs">'
+        '<link rel="alternate" data-content-gate="active">'
+        '<base data-subscription-wall="true">'
+        '<script>const marker = "<div data-paywall>";</script>'
+        '<article><p>Documentation.</p></article>'
+    )
+    assert detect_page_type(html, "https://x.com", "text/html", 80) == "article"
+
+
+def test_page_type_paywall_phrase_in_nonvisible_markup_is_not_a_paywall():
+    html = (
+        '<script>const prompt = "subscribe to continue";</script>'
+        '<style>.prompt::after { content: "subscribe to read"; }</style>'
+        '<noscript>Sign in to continue reading.</noscript>'
+        '<template><div data-paywall>Subscriber-only content.</div></template>'
+        '<!-- <div data-paywall="true">subscribe to continue</div> -->'
+        '<article><p>Documentation.</p></article>'
+    )
+    assert detect_page_type(html, "https://x.com", "text/html", 80) == "article"
+
+
+def test_page_type_disabled_or_prefixed_structural_markers_are_not_paywalls():
+    attributes = (
+        'data-paywall="false"',
+        "data-content-gate='off'",
+        "data-subscription-wall=0",
+        'data-paywall-state="open"',
+        'data-content-gate-config="enabled"',
+        'x-data-paywall="true"',
+        'aria-data-paywall="true"',
+        'class="data-paywall enabled"',
+        'title="data-content-gate=true"',
+    )
+    for attribute in attributes:
+        html = f"<article><div {attribute}>Public content.</div></article>"
+        assert detect_page_type(html, "https://x.com", "text/html", 80) == "article"
+
+
+def test_page_type_structural_paywall_markers_are_paywalls():
+    html_values = (
+        '<main><div data-paywall="true">Subscription required.</div></main>',
+        '<aside data-content-gate>Subscription required.</aside>',
+        "<section data-content-gate='yes'>Subscription required.</section>",
+        '<div data-paywall=enabled>Subscription required.</div>',
+        '<main data-subscription-wall="active">Subscription required.</main>',
+    )
+    for html in html_values:
+        assert detect_page_type(html, "https://x.com", "text/html", 80) == "paywall"
 
 
 def test_page_type_redirect_meta_refresh():


### PR DESCRIPTION
**Summary**
Fix false-positive paywall classification for public pages whose raw HTML merely contains the token `paywall`.
- Remove the bare `paywall` substring marker from `detect_page_type()`.
- Parse with `HTMLParser`; match subscription phrases against visible rendered text only, resolving character references and inline formatting.
- Accept only exact structural attribute names (`data-paywall`, `data-content-gate`, `data-subscription-wall`); reject false-like values, foreign/prefixed names, and value–name impersonations.
- Exclude non-visible regions (`<script>`, `<style>`, `<noscript>`, `<template>`, comments).
- Add focused regression coverage; note under `## [Unreleased]` in `CHANGELOG.md`.

**Lane:** Fetch / Extract — page-type classification in `envelope.py`.
**Type:** Bug fix (non-breaking) · Reliability/hardening. Internal classifier correction; no user-facing surface change.

**Reproduction**
Against `https://github.com/dondai1234/master-fetch`, the README `login/paywall` reference alone produced HTTP 200, `content_ok=true`, `page_type=paywall` before the change; after the change the page is not classified as a paywall and no paywall recovery runs.

**Test evidence**
```text
pytest tests/test_v10_envelope.py   → 36 passed
pytest tests/                       → 814 passed, 1 skipped, 5 deselected
compileall src tests                → ok
ruff check envelope.py + test file  → all checks passed
git diff --check                    → clean
```
Coverage confirms: explanatory text ("paywall detector"), README `login/paywall` links, and script/meta/style/noscript/template/comment mentions are not paywalls; disabled/false-like or prefixed/foreign attributes are not paywalls; character references and inline boundaries do not break real detection; concrete visible prompts and active exact attributes still classify as paywall. The two suite warnings are pre-existing `PytestRemovedIn10Warning` messages from `tests/test_reddit.py`. A separate structural heuristic classifies that GitHub page as `qa`; that classifier is out of scope here.

Fixes #6
