### PR TITLE
Exclude GitHub system routes from repository case folding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
   `evilgithub.com` and `github.com.evil.test` while preserving real subdomains.
 - GitHub repository case variants now deduplicate in `smart_search`. Owner and
   repo name are treated as case-insensitive for `github.com` URLs, while branch
-  and file-path casing remains unchanged. Credential-bearing URLs skip the
-  GitHub-specific folding.
+  and file-path casing remains unchanged. Known GitHub system routes such as
+  `/topics` and `/settings` are excluded from repository-specific case folding.
+  Credential-bearing URLs skip the GitHub-specific folding.
 - `detect_page_type()` no longer classifies a page as a paywall solely because
   raw HTML contains the bare token `paywall`. Concrete visible subscription
   prompts and active, exact paywall data attributes remain signals; false-like

--- a/src/master_fetch/search_metasearch.py
+++ b/src/master_fetch/search_metasearch.py
@@ -787,6 +787,12 @@ _SEARCH_TRACKING_PARAMS = {
 }
 
 _GITHUB_REPO_HOSTS = {"github.com", "www.github.com"}
+_GITHUB_RESERVED_ROUTES = frozenset({
+    "about", "apps", "codespaces", "collections", "dashboard", "explore",
+    "features", "issues", "login", "marketplace", "new", "notifications",
+    "orgs", "pricing", "pulls", "search", "security", "settings", "sponsors",
+    "topics", "trending",
+})
 
 
 def _normalize_url(url: str) -> str:
@@ -798,7 +804,8 @@ def _normalize_url(url: str) -> str:
     stay distinct. Also lowercases scheme+host and strips non-root trailing slash.
     GitHub repository owner and name are case-insensitive, so their first two
     nonempty path segments are lowercased for github.com and www.github.com;
-    later path segments remain unchanged because branches and file paths can be
+    known GitHub system routes are excluded from this repository-specific rule.
+    Later path segments remain unchanged because branches and file paths can be
     case-sensitive. Credential-bearing URLs skip GitHub-specific path folding so
     opaque userinfo is never part of a newly introduced canonical collision.
     www.github.com retains its distinct host rather than adding a separate
@@ -816,7 +823,10 @@ def _normalize_url(url: str) -> str:
     if p.hostname in _GITHUB_REPO_HOSTS and p.username is None and p.password is None:
         segments = path.split("/")
         repo_segment_indexes = [i for i, segment in enumerate(segments) if segment][:2]
-        if len(repo_segment_indexes) == 2:
+        if (
+            len(repo_segment_indexes) == 2
+            and segments[repo_segment_indexes[0]].lower() not in _GITHUB_RESERVED_ROUTES
+        ):
             for i in repo_segment_indexes:
                 segments[i] = segments[i].lower()
             path = "/".join(segments)

--- a/tests/test_search_engines.py
+++ b/tests/test_search_engines.py
@@ -43,6 +43,12 @@ def test_normalize_url_adds_scheme_to_protocol_relative():
     assert normalize_url("//example.com/x") == "https://example.com/x"
 
 
+def test_metasearch_normalize_preserves_github_reserved_routes():
+    assert ms._normalize_url("https://github.com/Settings/Keys") == (
+        "https://github.com/Settings/Keys"
+    )
+
+
 def test_index_family_bing_group():
     # duckduckgo + yahoo share Bing's index -> same family
     assert _INDEX_FAMILY["duckduckgo"] == _INDEX_FAMILY["yahoo"] == "bing"
@@ -288,6 +294,24 @@ def test_metasearch_merges_github_repo_case_variants_into_consensus(monkeypatch)
         "https://github.com/NousResearch/hermes-agent",
     }
     assert set(res[0]["backends"]) == {"brave", "yahoo"}
+    assert status["brave"] == "ok" and status["yahoo"] == "ok"
+
+
+def test_metasearch_keeps_github_reserved_route_case_variants_distinct(monkeypatch):
+    _patch_engines(monkeypatch, {
+        "brave": _fake_engine_class(
+            "brave", [_TR("Python topics", "https://github.com/topics/Python")]
+        ),
+        "yahoo": _fake_engine_class(
+            "yahoo", [_TR("python topics", "https://github.com/topics/python")]
+        ),
+    })
+    res, status = asyncio.run(ms.metasearch("python", 6, engines=["brave", "yahoo"]))
+    assert {item["href"] for item in res} == {
+        "https://github.com/topics/Python",
+        "https://github.com/topics/python",
+    }
+    assert all(len(item["backends"]) == 1 for item in res)
     assert status["brave"] == "ok" and status["yahoo"] == "ok"
 
 


### PR DESCRIPTION
## Summary

PR #8 added GitHub owner/repository case folding for metasearch deduplication. This follow-up excludes known GitHub system routes from that repository-specific rule.

Without the guard, URLs such as `https://github.com/topics/Python` and `https://github.com/topics/python` receive the same dedup key even though `/topics` is a GitHub route rather than a repository owner. That can merge distinct results and inflate cross-backend consensus.

## Implementation

- Add a module-level frozen set of known GitHub reserved first-path segments.
- Apply owner/repository case folding only when the first nonempty segment is not reserved.
- Compare the first segment case-insensitively against the reserved set.
- Keep real repository deduplication and all existing branch/file-path, userinfo, port, encoding, and host behavior unchanged.

## Tests

- Existing real-repository case-variant consensus test remains green.
- `/topics/Python` and `/topics/python` remain separate results.
- `/Settings/Keys` retains its original path casing, verifying a case-insensitive guard.
- Focused search tests: **48 passed**.
- Full suite: **834 passed, 1 skipped, 5 deselected**.
- `git diff --check`: clean.

Follow-up to #8.
