### PR TITLE
fix(mcp): forward focus and actions to smart_fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Forward the documented `focus` and `actions` arguments from the MCP tool dispatcher to `smart_fetch`.
+
 ## [11.2.0] - 2026-07-23
 
 ### Added: Six-signal search ranking

--- a/src/master_fetch/server.py
+++ b/src/master_fetch/server.py
@@ -3077,6 +3077,8 @@ class MasterFetchServer:
             timeout = args.get("timeout") if args.get("timeout") is not None else options.get("timeout")
             pages = args.get("pages") if args.get("pages") is not None else options.get("pages")
             password = args.get("password") if args.get("password") is not None else options.get("password")
+            focus = args.get("focus") if args.get("focus") is not None else options.get("focus")
+            actions = args.get("actions") if args.get("actions") is not None else options.get("actions")
             kw = {k: v for k, v in options.items() if k in (
                 "proxy", "cookies", "extra_headers", "useragent",
                 "wait", "network_idle", "headless", "real_chrome", "respect_robots",
@@ -3091,6 +3093,8 @@ class MasterFetchServer:
                 timeout=timeout if timeout is not None else 30000,
                 pages=pages,
                 password=password,
+                focus=focus,
+                actions=actions,
                 cache_ttl=args.get("cache_ttl", DEFAULT_TTL),
                 force_fetcher=args.get("force_fetcher"),
                 offset=args.get("offset", 0), **kw,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,7 +13,7 @@ from master_fetch.server import (
     _agent_hints, _apply_chunking, _is_cloudflare_from_response,
     _annotate_quality, MAX_CONTENT_CHARS, MIN_CHUNK_CHARS, MAX_BULK_URLS,
     _JS_SHELL_SIGNALS, _CF_CHALLENGE_SIGNALS, MAX_RESPONSE_BYTES,
-    _browser_deps_available,
+    _browser_deps_available, MasterFetchServer,
 )
 
 
@@ -26,6 +26,49 @@ def _make_result(**kwargs):
     )
     defaults.update(kwargs)
     return ResponseModel(**defaults)
+
+
+class TestMCPDispatch:
+
+    @pytest.mark.asyncio
+    async def test_smart_fetch_forwards_focus_and_actions(self):
+        server = MasterFetchServer()
+        server.smart_fetch = AsyncMock(return_value=_make_result())
+        actions = [{"click": "button.load-more"}]
+
+        await server._dispatch("mcp_smart_fetch", {
+            "url": "https://example.com",
+            "focus": "release notes",
+            "actions": actions,
+        })
+
+        call = server.smart_fetch.await_args
+        assert call is not None
+        kwargs = call.kwargs
+        assert kwargs["focus"] == "release notes"
+        assert kwargs["actions"] == actions
+
+    @pytest.mark.asyncio
+    async def test_top_level_focus_and_actions_override_options(self):
+        server = MasterFetchServer()
+        server.smart_fetch = AsyncMock(return_value=_make_result())
+        top_actions = [{"press": "Enter"}]
+
+        await server._dispatch("mcp_smart_fetch", {
+            "url": "https://example.com",
+            "focus": "top level",
+            "actions": top_actions,
+            "options": {
+                "focus": "legacy option",
+                "actions": [{"wait": 1000}],
+            },
+        })
+
+        call = server.smart_fetch.await_args
+        assert call is not None
+        kwargs = call.kwargs
+        assert kwargs["focus"] == "top level"
+        assert kwargs["actions"] == top_actions
 
 
 # ─── JS shell detection ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
Forward the documented MCP `focus` and `actions` arguments from `_dispatch()` to `smart_fetch()`. Top-level values win over values in the legacy `options` bag.

## Type of change
- [x] Bug fix (non-breaking)

## Checklist
- [x] Functional behavior changes; no cosmetic-only change.
- [x] Regression tests fail on v11.2.0 without this patch.
- [x] `pytest tests/` passes locally: `468 passed, 5 deselected`.
- [x] No new module-level import in `server.py`.
- [x] `CHANGELOG.md` updated under `Unreleased`.
- [x] Tool schema already documents these fields; no schema change is required.

## Notes for review
This is intentionally a narrow dispatch fix. `smart_fetch` already implements focus filtering and action handling; the MCP adapter simply dropped the two values before they reached that implementation.

Fixes #14