### PR TITLE
fix(browser): clean partial sessions after startup failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Clean up partially created browser contexts, Playwright instances, and temporary profiles when browser startup fails.
+
 ## [11.2.0] - 2026-07-23
 
 ### Added: Six-signal search ranking

--- a/src/master_fetch/browser.py
+++ b/src/master_fetch/browser.py
@@ -1030,25 +1030,40 @@ class BrowserSession:
             logger.info(f"Browser session started (stealthy={self._is_stealthy})")
         except Exception as e:
             logger.error(f"Browser session start failed: {e}")
-            await self._cleanup_playwright()
+            # start() can fail after a context/browser or temporary profile was
+            # created. close() also handles partially initialized sessions.
+            await self.close()
             raise
 
     async def close(self) -> None:
         """Close the browser and cleanup."""
-        if not self._is_alive:
+        if not any((
+            self._is_alive,
+            self._context is not None,
+            self._browser is not None,
+            self._playwright is not None,
+            self._user_data_dir is not None,
+        )):
             return
 
-        try:
-            if self._context:
+        if self._context:
+            try:
                 await self._context.close()
+            except Exception as e:
+                logger.debug(f"Error closing browser context: {e}")
+            finally:
                 self._context = None
-            if self._browser:
+        if self._browser:
+            try:
                 await self._browser.close()
+            except Exception as e:
+                logger.debug(f"Error closing browser: {e}")
+            finally:
                 self._browser = None
-        except Exception as e:
-            logger.debug(f"Error closing browser: {e}")
-        finally:
+
+        try:
             await self._cleanup_playwright()
+        finally:
             self._is_alive = False
 
             # Cleanup temp dir

--- a/tests/test_browser_lifecycle.py
+++ b/tests/test_browser_lifecycle.py
@@ -1,0 +1,78 @@
+"""Browser lifecycle regression tests."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import master_fetch.browser as browser_module
+from master_fetch.browser import DynamicBrowser
+
+
+@pytest.mark.asyncio
+async def test_start_failure_removes_partial_profile_and_stops_playwright(
+    monkeypatch, tmp_path
+):
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    playwright = SimpleNamespace(
+        chromium=SimpleNamespace(
+            launch_persistent_context=AsyncMock(
+                side_effect=RuntimeError("browser launch failed")
+            )
+        ),
+        stop=AsyncMock(),
+    )
+    manager = SimpleNamespace(start=AsyncMock(return_value=playwright))
+
+    monkeypatch.setattr("patchright.async_api.async_playwright", lambda: manager)
+    monkeypatch.setattr(browser_module, "_detect_chrome_channel", lambda: None)
+    monkeypatch.setattr(
+        browser_module.tempfile, "mkdtemp", lambda **_kwargs: str(profile)
+    )
+
+    session = DynamicBrowser(real_chrome=False)
+    with pytest.raises(RuntimeError, match="browser launch failed"):
+        await session.start()
+
+    playwright.stop.assert_awaited_once()
+    assert not profile.exists()
+    assert session._playwright is None
+    assert session._user_data_dir is None
+    assert session._is_alive is False
+
+
+@pytest.mark.asyncio
+async def test_start_failure_after_launch_closes_context(monkeypatch, tmp_path):
+    profile = tmp_path / "profile"
+    profile.mkdir()
+    context = SimpleNamespace(
+        add_cookies=AsyncMock(side_effect=RuntimeError("cookie setup failed")),
+        close=AsyncMock(),
+    )
+    playwright = SimpleNamespace(
+        chromium=SimpleNamespace(
+            launch_persistent_context=AsyncMock(return_value=context)
+        ),
+        stop=AsyncMock(),
+    )
+    manager = SimpleNamespace(start=AsyncMock(return_value=playwright))
+
+    monkeypatch.setattr("patchright.async_api.async_playwright", lambda: manager)
+    monkeypatch.setattr(browser_module, "_detect_chrome_channel", lambda: None)
+    monkeypatch.setattr(
+        browser_module.tempfile, "mkdtemp", lambda **_kwargs: str(profile)
+    )
+
+    session = DynamicBrowser(
+        real_chrome=False,
+        cookies=[{"name": "session", "value": "x", "domain": "example.com"}],
+    )
+    with pytest.raises(RuntimeError, match="cookie setup failed"):
+        await session.start()
+
+    context.close.assert_awaited_once()
+    playwright.stop.assert_awaited_once()
+    assert not profile.exists()
+    assert session._context is None
+    assert session._playwright is None


### PR DESCRIPTION
## Summary
Make browser shutdown handle partially initialized sessions, and route `start()` failures through that cleanup path. This releases a created context/browser, stops Playwright, and removes the temporary persistent profile even before `_is_alive` becomes true.

## Type of change
- [x] Reliability / hardening

## Checklist
- [x] Functional failure-path fix, not a cosmetic change.
- [x] New regression tests fail before the fix.
- [x] `pytest tests/` passes locally: `468 passed, 5 deselected`.
- [x] No new module-level import in `server.py`.
- [x] `CHANGELOG.md` updated under `Unreleased`.

## Notes for review
The change preserves normal successful shutdown. It additionally avoids one failed close blocking cleanup of a later resource by closing the context and browser independently.

Fixes #15