### PR TITLE
fix(updater): allow verified rollback to a pinned version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Let `hound --rollback` install the recorded older version and verify that the pinned target was installed exactly.
+
 ## [11.2.0] - 2026-07-23
 
 ### Added: Six-signal search ranking

--- a/src/master_fetch/updater.py
+++ b/src/master_fetch/updater.py
@@ -97,11 +97,11 @@ def _at_or_ahead(installed: str, target: str) -> bool:
 
 
 def _advanced(new_ver: str, target: str) -> bool:
-    """True if, after a pip run, the installed version reached the target."""
+    """True if a pinned pip run installed the requested target exactly."""
     if not new_ver or new_ver == "unknown":
         return False
     try:
-        return pad_version(new_ver) >= pad_version(target)
+        return pad_version(new_ver) == pad_version(target)
     except (ValueError, IndexError):
         return new_ver == target
 
@@ -485,7 +485,7 @@ def _advanced(new):
         return False
     np, tp = _pad(new), _pad(TARGET)
     if np and tp:
-        return np >= tp
+        return np == tp
     return new == TARGET
 
 _wait_parent_exit()
@@ -558,6 +558,7 @@ def do_update(target: str | None = None) -> None:
     None means the latest on PyPI. See the module docstring for the design."""
     from master_fetch import cli_ui as ui
     installed, latest, _is_current = check_version()
+    pinned_target = target is not None
     if target is None:
         target = latest
 
@@ -567,7 +568,12 @@ def do_update(target: str | None = None) -> None:
         print("  " + ui.warn("check your connection, then") + "  " + ui.cmd("hound -u"))
         return
 
-    if _at_or_ahead(installed, target):
+    # A pinned target is also the rollback mechanism, so an explicitly older
+    # version must not be treated as "up to date". Only an exact pinned match
+    # can return early; latest-version updates retain the at-or-ahead guard.
+    if _advanced(installed, target) or (
+        not pinned_target and _at_or_ahead(installed, target)
+    ):
         print(ui.branded(ui.ver(installed), ui.ok("up to date")))
         return
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,10 @@ import sys
 import pytest
 from unittest.mock import patch, MagicMock
 from master_fetch.cli import main, _run_repair
-from master_fetch.updater import check_version, pad_version, _at_or_ahead
+from master_fetch.updater import (
+    check_version, pad_version, _at_or_ahead, _advanced, _build_helper_source,
+    do_update, rollback,
+)
 
 
 # ─── CLI self-heal structure ───────────────────────────────────────
@@ -109,3 +112,44 @@ class TestVersionComparison:
 
     def test_malformed_installed(self):
         assert _at_or_ahead("not-a-version", "11.1.6") is False
+
+
+class TestRollback:
+
+    def test_post_install_verification_requires_exact_target(self):
+        assert _advanced("11.1.10", "11.1.10") is True
+        assert _advanced("11.2.0", "11.1.10") is False
+
+    def test_windows_helper_verification_requires_exact_target(self):
+        source = _build_helper_source("11.1.10", "repair.py", 1234)
+        assert "return np == tp" in source
+
+    def test_do_update_installs_explicit_older_target(self):
+        versions = [
+            ("11.2.0", "11.2.0", True),
+            ("11.1.10", "11.2.0", False),
+            ("11.1.10", "11.2.0", False),
+        ]
+        with patch("master_fetch.updater.check_version", side_effect=versions), \
+             patch("master_fetch.updater._write_repair_script"), \
+             patch("master_fetch.updater._write_last_version") as write_last, \
+             patch("master_fetch.updater._other_hound_pids", return_value=[]), \
+             patch("master_fetch.updater._spawn_helper", return_value=True) as spawn_helper, \
+             patch("master_fetch.updater._run_pip", return_value=(0, "")) as run_pip:
+            do_update(target="11.1.10")
+
+        write_last.assert_called_once_with("11.2.0")
+        if sys.platform == "win32":
+            spawn_helper.assert_called_once()
+            assert spawn_helper.call_args.args[0] == "11.1.10"
+            run_pip.assert_not_called()
+        else:
+            assert "hound-mcp==11.1.10" in run_pip.call_args.args[0]
+
+    def test_rollback_uses_recorded_version(self):
+        with patch("master_fetch.updater._read_last_version", return_value="11.1.10"), \
+             patch("master_fetch.updater.check_version", return_value=("11.2.0", "11.2.0", True)), \
+             patch("master_fetch.updater.do_update") as update:
+            rollback()
+
+        update.assert_called_once_with(target="11.1.10")


### PR DESCRIPTION
## Summary
Allow `do_update(target=...)` to install an explicitly older target for `hound --rollback`. Change post-install verification from “at or above target” to exact target equality, including the generated Windows helper.

## Type of change
- [x] Bug fix (non-breaking)

## Checklist
- [x] Functional behavior changes; no cosmetic-only change.
- [x] Regression tests fail on v11.2.0 without this patch.
- [x] `pytest tests/` passes locally: `470 passed, 5 deselected`.
- [x] `CHANGELOG.md` updated under `Unreleased`.

## Notes for review
Normal `hound -u` behavior is unchanged: it still treats an installed version at or ahead of PyPI latest as current. Only an explicit pinned target bypasses that early-return guard, which is necessary for rollback.

Fixes #16