### PR TITLE
fix: honor proxies in stealthy smart fetch

### DIFF
--- a/src/master_fetch/browser.py
+++ b/src/master_fetch/browser.py
@@ -813,7 +813,7 @@ class BrowserSession:
 
     Manages a persistent browser context with page pooling. Supports:
     - Headless/headful mode
-    - Proxy (static or per-request)
+    - Proxy (fixed for the session lifetime)
     - Resource blocking (disable_resources, blocked_domains)
     - Wait strategies (load, domcontentloaded, networkidle)
     - Page actions (callable executed after navigation)
@@ -1107,10 +1107,16 @@ class BrowserSession:
     ) -> "Any":
         """Navigate to a URL and return a Response object.
 
-        Parameters override session defaults for this request only.
+        Parameters override session defaults for this request only. Proxy is
+        fixed at session startup and cannot be changed here.
         """
         if not self._is_alive:
             raise RuntimeError("Session not started")
+        if proxy is not None and proxy != self._proxy:
+            raise ValueError(
+                "Proxy is fixed when a browser session starts; "
+                "open a new session to use a different proxy"
+            )
 
         # Resolve per-request overrides
         actual_wait = wait if wait is not None else self._wait

--- a/src/master_fetch/server.py
+++ b/src/master_fetch/server.py
@@ -2568,7 +2568,11 @@ class MasterFetchServer:
             return await self._finalize_result(result, url, extraction_type, css_selector, cache_ttl, offset, max_chars)
 
         else:  # stealthy ("dynamic" also routes here — Patchright handles everything)
-            ssid = await self._ensure_auto_session("stealthy")
+            # Playwright fixes the proxy when the browser context starts.
+            # The shared auto-session is direct, so a proxied request must use
+            # the one-off path where bulk_stealthy_fetch constructs the browser
+            # with the requested proxy.
+            ssid = None if proxy else await self._ensure_auto_session("stealthy")
             result = await self.stealthy_fetch(
                 url, extraction_type=extraction_type,
                 css_selector=css_selector, main_content_only=main_content_only,
@@ -2656,7 +2660,9 @@ class MasterFetchServer:
 
         errors.append(f"HTTP failed (status {result.status})")
         remaining = max(timeout - int((now() - start_time) * 1000), 5000)
-        ssid = await self._ensure_auto_session("stealthy")
+        # Playwright fixes the proxy when the browser context starts. Do not
+        # route a proxied request through the shared direct auto-session.
+        ssid = None if proxy else await self._ensure_auto_session("stealthy")
         result = await self.stealthy_fetch(
             url, extraction_type=extraction_type,
             css_selector=css_selector, main_content_only=main_content_only,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -71,6 +71,50 @@ class TestMCPDispatch:
         assert kwargs["actions"] == top_actions
 
 
+class TestSmartFetchProxy:
+
+    @pytest.mark.asyncio
+    async def test_forced_stealthy_proxy_bypasses_direct_auto_session(self):
+        server = MasterFetchServer()
+        server._ensure_auto_session = AsyncMock(return_value="direct-session")
+        server.stealthy_fetch = AsyncMock(
+            return_value=_make_result(fetcher_used="stealthy")
+        )
+        server._finalize_result = AsyncMock(side_effect=lambda result, *args: result)
+
+        await server.smart_fetch(
+            "https://example.com",
+            force_fetcher="stealthy",
+            proxy="http://127.0.0.1:8080",
+            cache_ttl=0,
+        )
+
+        server._ensure_auto_session.assert_not_awaited()
+        assert server.stealthy_fetch.await_args.kwargs["session_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_auto_escalation_proxy_bypasses_direct_auto_session(self):
+        server = MasterFetchServer()
+        server._http_with_retry = AsyncMock(
+            return_value=_make_result(status=403, content=["Forbidden"])
+        )
+        server._ensure_auto_session = AsyncMock(return_value="direct-session")
+        server.stealthy_fetch = AsyncMock(
+            return_value=_make_result(fetcher_used="stealthy")
+        )
+        server._finalize_result = AsyncMock(side_effect=lambda result, *args: result)
+
+        with patch("master_fetch.server._browser_deps_available", return_value=True):
+            await server.smart_fetch(
+                "https://example.com",
+                proxy="http://127.0.0.1:8080",
+                cache_ttl=0,
+            )
+
+        server._ensure_auto_session.assert_not_awaited()
+        assert server.stealthy_fetch.await_args.kwargs["session_id"] is None
+
+
 # ─── JS shell detection ───────────────────────────────────────────
 
 class TestIsJsShell:

--- a/tests/test_stealth.py
+++ b/tests/test_stealth.py
@@ -11,7 +11,7 @@ import pytest
 from master_fetch.browser import (
     DEFAULT_ARGS, HARMFUL_ARGS, STEALTH_ARGS,
     _FINGERPRINT_PROFILES, _generate_fingerprint_profile,
-    _build_stealth_init_script,
+    _build_stealth_init_script, StealthyBrowser,
 )
 
 
@@ -39,6 +39,20 @@ class TestBrowserArgs:
         for harmful in HARMFUL_ARGS:
             assert harmful not in STEALTH_ARGS
             assert harmful not in DEFAULT_ARGS
+
+
+class TestSessionProxy:
+
+    @pytest.mark.asyncio
+    async def test_active_session_rejects_different_proxy(self):
+        session = StealthyBrowser()
+        session._is_alive = True
+
+        with pytest.raises(ValueError, match="Proxy is fixed"):
+            await session.fetch(
+                "https://example.com",
+                proxy="http://127.0.0.1:8080",
+            )
 
 
 # ─── Fingerprint profiles ─────────────────────────────────────────


### PR DESCRIPTION
![AI coding model: gpt-5.6-sol high](https://img.shields.io/badge/AI_coding_model-gpt--5.6--sol_high-6f42c1)

> This pull request was generated with OpenAI Codex using `gpt-5.6-sol` at `high` effort. It addresses behavior reproduced in a local Hound playground; it is not a hypothetical report.

## Problem

A forced or auto-escalated stealthy `smart_fetch` silently uses the shared prewarmed browser even when the caller supplies `proxy`. That browser context was created without the request proxy, and Playwright cannot change a context proxy after launch. The request therefore leaves through the machine's direct connection.

A deliberately unreachable proxy makes the leak visible:

```python
await server.smart_fetch(
    "https://example.com",
    force_fetcher="stealthy",
    proxy="http://127.0.0.1:1",
    cache_ttl=0,
)
```

Before this change, the call unexpectedly returns `200` from the stealthy tier. A dead proxy should make the request fail, not succeed directly.

## Fix

- Bypass the direct auto-session when a stealthy smart fetch has a proxy. The existing one-off path then constructs its browser context with that proxy.
- Keep the prewarmed browser behavior unchanged for requests without a proxy.
- Reject attempts to change the proxy on an explicit active browser session instead of silently ignoring the override.
- Cover both forced-stealthy and HTTP-to-stealthy routing, plus the active-session guard.

The deliberate tradeoff is that proxied browser fetches pay a cold browser start and do not inherit the direct auto-session's cookies. Proxy-provider stickiness still works when encoded in provider credentials because each new context connects through the same sticky endpoint. A proxy-keyed warm-session cache or proxy-pool policy would be a separate feature.

## History: how this was left behind

- In v1.0.0 (June 1), browser fetches used one-off sessions, so the proxy was supplied when the browser session was constructed.
- v1.0.3 (also June 1) introduced persistent auto-sessions for latency. Smart-fetch routing began supplying both an auto `session_id` and the request-level `proxy` downstream.
- The v11.0.0 rewrite (July 21) replaced Scrapling with the current Playwright/Patchright browser implementation. `BrowserSession.start()` correctly applies `self._proxy` while creating the context, but `BrowserSession.fetch(proxy=...)` retained the per-request argument and its “override session defaults” contract without applying it.

This was easy to miss because every public layer still validates and forwards `proxy`: `smart_fetch` → `stealthy_fetch` → `bulk_stealthy_fetch` → `BrowserSession.fetch`. The plumbing looks intact in review, and normal success tests still return content—through the direct connection. There was no regression test using an unreachable proxy to prove which network path the browser actually took. In other words, the optimization and later browser rewrite preserved the API shape but lost the proxy's context-creation semantics.

## Verification

Environment: macOS 26.1, Python 3.13.11.

```text
pytest tests/
676 passed, 5 deselected in 5.35s
```
