### PR TITLE
fix(robots): replace invalid 'stealthy_headers' parameter with 'impersonate' in HTTPSession

### DIFF
--- a/src/master_fetch/robots.py
+++ b/src/master_fetch/robots.py
@@ -48,7 +48,7 @@ async def _fetch_robots_txt(domain: str) -> str | None:
     """
     try:
         from master_fetch.fetcher import HTTPSession
-        async with HTTPSession(stealthy_headers=False, retries=1) as sess:
+        async with HTTPSession(impersonate="chrome", retries=1) as sess:
             response = await sess.get(
                 f"https://{domain}/robots.txt", timeout=_FETCH_TIMEOUT,
             )


### PR DESCRIPTION

### Summary of Changes

- Updated `HTTPSession` instantiation in `src/master_fetch/robots.py` to use `impersonate="chrome"` instead of the invalid `stealthy_headers=False` keyword argument.
- Fixes internal `TypeError` during `robots.txt` fetching so async primp HTTP session execution works cleanly without silently triggering the `urllib` fallback.

### Verification

- Verified `_fetch_robots_txt("google.com")` via async event loop; confirmed primp HTTP session succeeds and returns raw content cleanly.
- Verified parameter signatures against `src/master_fetch/fetcher.py`.

Fixes #<22>
