### PR TITLE
fix(fetch): isolate and forward smart-fetch focus context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Scope `smart_fetch` request context to each invocation and forward `focus`
+  through bulk URL fetches, preventing filters from leaking or being ignored.
+
 ## [12.3.0] - 2026-07-23
 
 ### Per-provider API optimization (critical for BYOK parity)

--- a/src/master_fetch/server.py
+++ b/src/master_fetch/server.py
@@ -19,6 +19,8 @@ import json
 import logging
 import os
 import sys
+import inspect
+from functools import wraps
 from uuid import uuid4
 import asyncio
 import contextvars
@@ -731,6 +733,33 @@ _FOCUS: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar("_focus",
 # Opt-in: populate ResponseModel.media with the page's image URLs (multimodal).
 _INCLUDE_MEDIA: contextvars.ContextVar[bool] = contextvars.ContextVar("_include_media", default=False)
 _INCLUDE_LINKS: contextvars.ContextVar[bool] = contextvars.ContextVar("_include_links", default=False)
+
+
+def _smart_fetch_request_context(func):
+    """Scope smart_fetch request options to one invocation and its child tasks."""
+    signature = inspect.signature(func)
+
+    @wraps(func)
+    async def wrapped(*args, **kwargs):
+        values = signature.bind(*args, **kwargs)
+        values.apply_defaults()
+        options = values.arguments
+        tokens = [
+            (_PDF_PAGES, _PDF_PAGES.set(options["pages"] if isinstance(options["pages"], str) else None)),
+            (_PDF_PASSWORD, _PDF_PASSWORD.set(options["password"] if isinstance(options["password"], str) else None)),
+            (_FOCUS, _FOCUS.set(options["focus"] if isinstance(options["focus"], str) and options["focus"].strip() else None)),
+            (_INCLUDE_MEDIA, _INCLUDE_MEDIA.set(bool(options["include_media"]))),
+            (_INCLUDE_LINKS, _INCLUDE_LINKS.set(bool(options["include_links"]))),
+        ]
+        try:
+            return await func(*args, **kwargs)
+        finally:
+            for variable, token in reversed(tokens):
+                variable.reset(token)
+
+    return wrapped
+
+
 def _extract_pdf_response(body: bytes, raw_ct: str, total_size: int, url: str,
                           extraction_type: str, fetcher_used: str, duration_ms: float) -> ResponseModel:
     """Build a ResponseModel from a PDF body using the flagship extractor."""
@@ -2303,6 +2332,7 @@ class MasterFetchServer:
             retry_count=max_retries + 1,
         )
 
+    @_smart_fetch_request_context
     async def smart_fetch(
         self,
         url: Annotated[str, Field(description="Single URL to fetch.")],
@@ -2367,6 +2397,7 @@ class MasterFetchServer:
                 headless, real_chrome, wait, proxy, timeout, network_idle,
                 solve_cloudflare, block_webrtc, hide_canvas, extra_headers,
                 useragent, cookies, max_content_chars, include_media, include_links,
+                focus,
             )
 
         # Validate all inputs
@@ -2384,17 +2415,9 @@ class MasterFetchServer:
             max_content_chars = min(max_content_chars, 200000)
         mc = max_content_chars if isinstance(max_content_chars, int) else MAX_CONTENT_CHARS
 
-        # PDF options flow down to _translate_response via contextvars (task-local,
-        # safe under concurrent bulk fetches) and into the cache key so a
-        # pages-subset extraction doesn't collide with a full-PDF cache entry.
-        _PDF_PAGES.set(pages if isinstance(pages, str) else None)
-        _PDF_PASSWORD.set(password if isinstance(password, str) else None)
-        # focus: set only when provided (truthy) so bulk-mode inner calls inherit
-        # the parent's focus via the gather context copy instead of resetting it.
-        if isinstance(focus, str) and focus.strip():
-            _FOCUS.set(focus)
-        _INCLUDE_MEDIA.set(bool(include_media))
-        _INCLUDE_LINKS.set(bool(include_links))
+        # Request options flow to lower-level fetchers through ContextVars. The
+        # decorator scopes them to this call so sequential requests cannot leak
+        # state into one another while concurrent bulk tasks remain isolated.
         # actions produce post-interaction content unique to the action sequence;
         # bypass the cache so a plain (pre-action) cached copy is never served.
         if actions:
@@ -2503,6 +2526,7 @@ class MasterFetchServer:
         solve_cloudflare, block_webrtc, hide_canvas, extra_headers,
         useragent, cookies, max_chars: int = MAX_CONTENT_CHARS,
         include_media: bool = False, include_links: bool = False,
+        focus: Optional[str] = None,
     ) -> BulkResponseModel:
         """Fetch multiple URLs in parallel through the smart fetch pipeline."""
         if len(urls) > MAX_BULK_URLS:
@@ -2524,6 +2548,7 @@ class MasterFetchServer:
                     useragent=useragent, cookies=cookies,
                     max_content_chars=max_chars,
                     include_media=include_media, include_links=include_links,
+                    focus=focus,
                 )
             except Exception as e:
                 return _with_agent_hints(ResponseModel(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,7 +9,7 @@ against real ResponseModel objects. No mocks of the functions themselves.
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 from master_fetch.server import (
-    ResponseModel, _is_js_shell, _detect_content_issue, _is_cacheable,
+    ResponseModel, BulkResponseModel, _is_js_shell, _detect_content_issue, _is_cacheable,
     _agent_hints, _apply_chunking, _is_cloudflare_from_response,
     _annotate_quality, MAX_CONTENT_CHARS, MIN_CHUNK_CHARS, MAX_BULK_URLS,
     _JS_SHELL_SIGNALS, _CF_CHALLENGE_SIGNALS, MAX_RESPONSE_BYTES,
@@ -113,6 +113,53 @@ class TestSmartFetchProxy:
 
         server._ensure_auto_session.assert_not_awaited()
         assert server.stealthy_fetch.await_args.kwargs["session_id"] is None
+
+
+class TestSmartFetchFocusContext:
+    @staticmethod
+    def _long_content_result():
+        return _make_result(content=[
+            "## Apples\nalpha fruit\n\n"
+            "## Bananas\nyellow fruit\n\n"
+            "## Carrots\norange vegetable"
+        ])
+
+    @pytest.mark.asyncio
+    async def test_bulk_fetch_forwards_focus_to_each_result(self):
+        server = MasterFetchServer()
+        server._http_with_retry = AsyncMock(return_value=self._long_content_result())
+
+        result = await server.smart_fetch(
+            "https://example.com",
+            urls=["https://example.com"],
+            focus="bananas",
+            cache_ttl=0,
+        )
+
+        assert isinstance(result, BulkResponseModel)
+        content = result.results[0].content[0]
+        assert "[Focus: 'bananas'" in content
+        assert "## Bananas" in content
+        assert "## Apples" not in content
+
+    @pytest.mark.asyncio
+    async def test_no_focus_call_does_not_inherit_previous_focus(self):
+        server = MasterFetchServer()
+        server._http_with_retry = AsyncMock(
+            side_effect=[self._long_content_result(), self._long_content_result()]
+        )
+
+        focused = await server.smart_fetch(
+            "https://example.com/first", focus="bananas", cache_ttl=0
+        )
+        unfiltered = await server.smart_fetch(
+            "https://example.com/second", cache_ttl=0
+        )
+
+        assert "[Focus: 'bananas'" in focused.content[0]
+        assert "[Focus:" not in unfiltered.content[0]
+        assert "## Apples" in unfiltered.content[0]
+        assert "## Bananas" in unfiltered.content[0]
 
 
 # ─── JS shell detection ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Scope the smart-fetch request ContextVars to one invocation and reset them afterward. Forward `focus` explicitly through the bulk URL path so every inner fetch applies the requested filter without leaking it into later calls.

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Functional behavior changes; no cosmetic-only change.
- [x] Regression tests fail on v12.3.0 without this patch.
- [x] `pytest tests/` passes locally: `701 passed, 5 deselected`.
- [x] No new heavy module-level import in `server.py`.
- [x] `CHANGELOG.md` updated under `Unreleased`.
- [x] Public `smart_fetch` signature remains intact (`inspect.signature` smoke-tested).
- [x] Tool schema is unchanged.

## Notes for review

The request wrapper uses ContextVar tokens with `try/finally`, so nested calls restore their parent context while sequential requests cannot inherit stale values. The bulk implementation passes `focus` to each inner `smart_fetch` call rather than depending on ambient context.

This deliberately stays within the existing ContextVar design and does not change extraction or ranking behavior.

Fixes #24
