### PR TITLE
fix(search): include explicit region in cache identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Scope `smart_fetch` request context to each invocation and forward `focus`
   through bulk URL fetches, preventing filters from leaking or being ignored.
+- Include an explicit normalized `region` in the `smart_search` cache identity
+  so searches for different regions cannot reuse each other's cached results.
 
 ## [12.3.0] - 2026-07-23
 

--- a/src/master_fetch/search.py
+++ b/src/master_fetch/search.py
@@ -996,6 +996,9 @@ async def smart_search(
                 error="find_similar requires a url (pass url=, or the URL as query).",
                 next_action="Pass url= with a page URL to find pages similar to it (or pass the URL as the query).")
 
+    # Preserve an explicit region for cache identity before deriving the
+    # location/language default used by search engines.
+    cache_region = str(region).strip().lower() if region is not None else None
     # region derives from location/language if not given (e.g. "US" -> "us-en").
     if region is None:
         loc = (location or "US").lower()
@@ -1003,7 +1006,13 @@ async def smart_search(
         region = f"{loc}-{lang}" if len(loc) == 2 else "us-en"
 
     cache_query = find_sim_url or query
-    cache_type = (f"search:v12:{max_results}:{site or ''}:{','.join(exclude_sites or [])}:"f"{location or ''}:{language or ''}:{page or 0}:{','.join(engines or [])}:"f"{freshness or ''}:{mode}:{cache_query}")
+    cache_type = (f"search:v12:{max_results}:{site or ''}:{','.join(exclude_sites or [])}:"
+                  f"{location or ''}:{language or ''}:{page or 0}:{','.join(engines or [])}:"
+                  f"{freshness or ''}:{mode}:{cache_query}")
+    # An explicit region is passed through to the engines, so keep it in the
+    # cache identity. Omitted regions retain the existing cache key behavior.
+    if cache_region is not None:
+        cache_type = f"{cache_type}:region={cache_region}"
     if cache_ttl > 0:
         cached = await get_cached(cache_query, cache_type, None, ttl=cache_ttl)
         if cached and cached.get("content"):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -10,12 +10,101 @@ real search results.
 import asyncio
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
+from master_fetch import search as search
 from master_fetch import search_engines as se
 from master_fetch.search_engines import (
     _passes_site_filter, _normalize_domain, _is_domain_or_subdomain,
     RawResult, EngineReport, multi_search, normalize_url,
     DEFAULT_ENGINES, _INDEX_FAMILY,
 )
+
+
+@pytest.fixture
+def smart_search_cache(monkeypatch):
+    """In-memory cache and deterministic search backend for cache-key tests."""
+    cache = {}
+    live_regions = []
+
+    async def fake_get_cached(query, cache_type, css_selector, **kwargs):
+        return cache.get((query, cache_type))
+
+    async def fake_set_cached(query, cache_type, content, status, css_selector, ttl):
+        cache[(query, cache_type)] = {"content": content}
+
+    async def fake_multi_search(query, max_results, **kwargs):
+        region = kwargs["region"]
+        live_regions.append(region)
+        return [RawResult(
+            title=f"Result for {region}",
+            url=f"https://{region}.example.test/",
+            snippet="regional result",
+            source="brave",
+            position=1,
+        )], [EngineReport(name="brave", ok=True)]
+
+    async def fake_ensure_reranker():
+        return None
+
+    monkeypatch.setattr(search, "get_cached", fake_get_cached)
+    monkeypatch.setattr(search, "set_cached", fake_set_cached)
+    monkeypatch.setattr(search, "multi_search", fake_multi_search)
+    monkeypatch.setattr(search, "ensure_reranker", fake_ensure_reranker)
+    monkeypatch.setattr(
+        search, "_rank",
+        lambda query, ranked, mode: (ranked, [1.0] * len(ranked), "merge", ""),
+    )
+    return cache, live_regions
+
+
+class TestSmartSearchRegionCache:
+
+    @pytest.mark.asyncio
+    async def test_explicit_regions_use_distinct_cache_entries(self, smart_search_cache):
+        cache, live_regions = smart_search_cache
+
+        us = await search.smart_search(
+            None, "regional cache test", engines=["brave"], region="us-en",
+        )
+        gb = await search.smart_search(
+            None, "regional cache test", engines=["brave"], region="gb-en",
+        )
+
+        assert us.cached is False
+        assert gb.cached is False
+        assert [us.results[0].title, gb.results[0].title] == [
+            "Result for us-en", "Result for gb-en",
+        ]
+        assert live_regions == ["us-en", "gb-en"]
+        assert len(cache) == 2
+
+    @pytest.mark.asyncio
+    async def test_same_normalized_explicit_region_uses_cached_result(self, smart_search_cache):
+        cache, live_regions = smart_search_cache
+
+        first = await search.smart_search(
+            None, "regional cache test", engines=["brave"], region="GB-EN",
+        )
+        second = await search.smart_search(
+            None, "regional cache test", engines=["brave"], region="gb-en",
+        )
+
+        assert first.cached is False
+        assert second.cached is True
+        assert second.results[0].title == "Result for GB-EN"
+        assert live_regions == ["GB-EN"]
+        assert len(cache) == 1
+
+    @pytest.mark.asyncio
+    async def test_omitted_region_keeps_existing_cache_key(self, smart_search_cache):
+        cache, _ = smart_search_cache
+
+        await search.smart_search(
+            None, "regional cache test", engines=["brave"],
+        )
+
+        assert list(cache) == [
+            ("regional cache test", "search:v12:6:::::0:brave::auto:regional cache test"),
+        ]
 
 
 # ─── Hostname boundary filtering (PR #7) ──────────────────────────


### PR DESCRIPTION
## Summary

Include an explicitly supplied, normalized `region` in the `smart_search` cache identity so requests for different regions cannot reuse each other's cached results.

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Functional behavior changes; no cosmetic-only change.
- [x] Regression tests fail on v12.3.0 without this patch.
- [x] `pytest tests/` passes locally: `702 passed, 5 deselected`.
- [x] No new heavy module-level import in `server.py`.
- [x] `CHANGELOG.md` updated under `Unreleased`.
- [x] No tool schema or public parameter change.

## Notes for review

The explicit region is normalized with `strip().lower()` for cache identity, so `GB-EN` and `gb-en` share an entry while `us-en` and `gb-en` do not. When `region` is omitted, the existing cache-key format is preserved to avoid invalidating unrelated cached searches.

Regression coverage checks distinct regional entries, normalized same-region reuse, and the omitted-region key format.

Fixes #25
