### PR TITLE
fix(byok): reconcile runtime key pools after config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   through bulk URL fetches, preventing filters from leaking or being ignored.
 - Include an explicit normalized `region` in the `smart_search` cache identity
   so searches for different regions cannot reuse each other's cached results.
+- Reconcile in-memory BYOK key pools with configuration changes so removed and
+  reordered keys take effect without restart while retained key state survives.
 
 ## [12.3.0] - 2026-07-23
 

--- a/src/master_fetch/search_api_keys.py
+++ b/src/master_fetch/search_api_keys.py
@@ -164,23 +164,32 @@ def _get_pool(provider: str) -> KeyPool | None:
 
 
 def _refresh_pools() -> None:
-    """Reload keys from config (env vars + config file). Rebuilds pools.
+    """Reload keys from config and reconcile pools with the configured keys.
 
-    Called lazily by _register_byok_backends() so new keys added via CLI
-    are picked up without restarting the server.
+    Called lazily by _register_byok_backends() so key additions, removals, and
+    reordered keys from the CLI are picked up without restarting the server.
     """
     all_keys = load_byok_keys()
     for provider in BYOK_PROVIDERS:
         keys = all_keys.get(provider, [])
         if keys:
             if provider in _POOLS:
-                # Update existing pool's keys (preserve state for existing keys).
+                # Keep state for retained keys, but make both pool membership and
+                # order exactly match the current configuration. Preserve the next
+                # surviving key in the old rotation where possible.
                 old_pool = _POOLS[provider]
-                new_keys = [k for k in keys if k not in old_pool._keys]
-                if new_keys:
-                    old_pool._keys.extend(new_keys)
-                    for k in new_keys:
-                        old_pool._state.setdefault(k, {})
+                old_keys = old_pool._keys
+                next_key = None
+                if old_keys:
+                    for offset in range(len(old_keys)):
+                        candidate = old_keys[(old_pool._idx + offset) % len(old_keys)]
+                        if candidate in keys:
+                            next_key = candidate
+                            break
+                old_state = old_pool._state
+                old_pool._keys = list(keys)
+                old_pool._state = {key: old_state.get(key, {}) for key in keys}
+                old_pool._idx = old_pool._keys.index(next_key) if next_key else 0
             else:
                 _POOLS[provider] = KeyPool(keys)
         else:

--- a/tests/test_byok.py
+++ b/tests/test_byok.py
@@ -838,6 +838,63 @@ class TestPoolManagement:
         _refresh_pools()
         assert _POOLS["serper"].size == 2
 
+    def test_refresh_pools_removes_deleted_keys_and_keeps_config_order(self, monkeypatch):
+        import master_fetch.search_api_keys as api_keys
+        api_keys._POOLS["serper"] = api_keys.KeyPool(["key1", "key2", "key3"])
+        monkeypatch.setattr(api_keys, "load_byok_keys", lambda: {"serper": ["key3", "key1"]})
+
+        api_keys._refresh_pools()
+
+        assert api_keys._POOLS["serper"]._keys == ["key3", "key1"]
+        assert "key2" not in api_keys._POOLS["serper"]._state
+
+    def test_refresh_pools_rotates_safely_when_next_key_is_deleted(self, monkeypatch):
+        import master_fetch.search_api_keys as api_keys
+        pool = api_keys.KeyPool(["key1", "key2", "key3"])
+        api_keys._POOLS["serper"] = pool
+        assert pool.get_key() == "key1"  # key2 is next in the rotation
+        monkeypatch.setattr(api_keys, "load_byok_keys", lambda: {"serper": ["key1", "key3"]})
+
+        api_keys._refresh_pools()
+
+        assert pool.get_key() == "key3"
+
+    def test_refresh_pools_rotates_safely_when_current_key_is_deleted(self, monkeypatch):
+        import master_fetch.search_api_keys as api_keys
+        pool = api_keys.KeyPool(["key1", "key2", "key3"])
+        api_keys._POOLS["serper"] = pool
+        assert pool.get_key() == "key1"
+        monkeypatch.setattr(api_keys, "load_byok_keys", lambda: {"serper": ["key2", "key3"]})
+
+        api_keys._refresh_pools()
+
+        assert pool._keys == ["key2", "key3"]
+        assert pool.get_key() == "key2"
+
+    def test_refresh_pools_preserves_retained_key_cooldown(self, monkeypatch):
+        import master_fetch.search_api_keys as api_keys
+        pool = api_keys.KeyPool(["key1", "key2"])
+        pool.mark_invalid("key2")
+        cooldown_until = pool._state["key2"]["rate_limited_until"]
+        api_keys._POOLS["serper"] = pool
+        monkeypatch.setattr(api_keys, "load_byok_keys", lambda: {"serper": ["key2", "key3"]})
+
+        api_keys._refresh_pools()
+
+        assert pool._state == {
+            "key2": {"rate_limited_until": cooldown_until, "error": "invalid"},
+            "key3": {},
+        }
+
+    def test_refresh_pools_removes_provider_without_keys(self, monkeypatch):
+        import master_fetch.search_api_keys as api_keys
+        api_keys._POOLS["serper"] = api_keys.KeyPool(["key1"])
+        monkeypatch.setattr(api_keys, "load_byok_keys", lambda: {})
+
+        api_keys._refresh_pools()
+
+        assert "serper" not in api_keys._POOLS
+
     def test_reset_clears_all_pools(self):
         from master_fetch.search_api_keys import _POOLS, _reset_byok_pools
         _POOLS["test"] = MagicMock()


### PR DESCRIPTION
## Summary

Reconcile existing in-memory BYOK key pools with the current configuration during refresh. Removed and reordered keys now take effect without a server restart while cooldown/health state for retained keys is preserved.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Reliability / hardening

## Checklist

- [x] Functional behavior changes; no cosmetic-only change.
- [x] Regression tests fail on v12.3.0 without this patch.
- [x] `pytest tests/` passes locally: `704 passed, 5 deselected`.
- [x] No new heavy module-level import in `server.py`.
- [x] `CHANGELOG.md` updated under `Unreleased`.
- [x] No config format or CLI surface change.

## Notes for review

The pool object is retained so active engine instances continue to reference it. Its key membership/order and state map are reconciled in place, and the rotation cursor is moved to the next surviving key where possible.

Tests cover partial removal and reordering, deletion around the rotation cursor, retained cooldown state, and complete provider removal.

Fixes #26
